### PR TITLE
Improve rawdataplot

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = False
-current_version = 1.9.0
+current_version = 1.9.1
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?
 serialize = 
 	{major}.{minor}.{patch}-{release}

--- a/fiberoptics/common/__init__.py
+++ b/fiberoptics/common/__init__.py
@@ -1,3 +1,3 @@
 from .misc import *  # noqa
 
-__version__ = "1.9.0"
+__version__ = "1.9.1"

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ extras_require["docs"] = [
 
 setup(
     name="fiberoptics-common",
-    version="1.9.0",
+    version="1.9.1",
     packages=PEP420PackageFinder.find(include=["fiberoptics.common*"]),
     install_requires=["pandas"],
     extras_require=extras_require,


### PR DESCRIPTION
NOTE
the ticker formatters do not work as expected, but the default tick labels are doing fine when plotting feature data. possibly worth checking in case of raw data plots and timespans in microseconds. so not deleting _ticker.py, but dropping its use