### PR TITLE
Fix failing documentation publishing workflow by upgrading pages deployment action to the latest version

### DIFF
--- a/.github/workflows/publish_sphinx_documentation.yml
+++ b/.github/workflows/publish_sphinx_documentation.yml
@@ -69,5 +69,5 @@ jobs:
       - uses: actions/upload-pages-artifact@v2
         with:
           path: "./docs/_build/html"
-      - uses: actions/deploy-pages@v3
+      - uses: actions/deploy-pages@v4
         id: deployment


### PR DESCRIPTION
Closes https://github.com/equinor/fiberoptics-common/issues/41