### PR TITLE
Bugfix failing documentation publishing workflow by upgrading pages deployment action to the latest version

### DIFF
--- a/.github/workflows/publish_sphinx_documentation.yml
+++ b/.github/workflows/publish_sphinx_documentation.yml
@@ -66,7 +66,7 @@ jobs:
           (cd docs; poetry run make html)
           poetry run ruff format --check --diff .
       - uses: actions/configure-pages@v4
-      - uses: actions/upload-pages-artifact@v2
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: "./docs/_build/html"
       - uses: actions/deploy-pages@v4


### PR DESCRIPTION
Follow-up on https://github.com/equinor/fiberoptics-common/pull/42