### PR TITLE
Suppress deprecation warnings by rewriting groupping logic without usage of groupby

### DIFF
--- a/fiberoptics/common/processing/__init__.py
+++ b/fiberoptics/common/processing/__init__.py
@@ -150,9 +150,10 @@ def depth_aggregation(df: pd.DataFrame, aggregation_window: int = 0, aggregation
     aggregated_dfs = []
     for grouped_df in grouped_dfs:
         columns = grouped_df.columns.levels[1] if grouped_df.columns.nlevels > 1 else grouped_df.columns
-        groups = grouped_df.groupby((columns / aggregation_window).astype("int") * aggregation_window, axis=1)
-        grouped_df: pd.DataFrame = getattr(groups, aggregation_function)()
-        aggregated_dfs.append(grouped_df)
+        grouped_columns = (columns // aggregation_window) * aggregation_window
+        grouped_df.columns = grouped_columns
+        aggregated_grouped_df = grouped_df.T.groupby(level=0).agg(aggregation_function).T
+        aggregated_dfs.append(aggregated_grouped_df)
 
     merged_df = pd.concat(aggregated_dfs, axis=1, keys=df.columns.levels[0]) if len(aggregated_dfs) > 1 else aggregated_dfs[0]
 

--- a/fiberoptics/common/processing/__init__.py
+++ b/fiberoptics/common/processing/__init__.py
@@ -139,16 +139,13 @@ def depth_aggregation(df: pd.DataFrame, aggregation_window: int = 0, aggregation
     if aggregation_window == 0:
         return df
 
-    # if df.columns.nlevels == 1:
-    #     groups = df.groupby(
-    #         (df.columns / aggregation_window).astype("int") * aggregation_window, axis=1
-    #     )
-    #     df: pd.DataFrame = getattr(groups, aggregation_function)()
-    #     return df
-
-    # Split the groups into a list of DataFrames
-    grouped = df.groupby(level=0, axis=1)
-    grouped_dfs = [grouped.get_group(group_name) for group_name in grouped.groups] if df.columns.nlevels > 1 else [df]
+    # Split the df into a list of DataFrames by featureIds
+    feature_ids = df.columns.get_level_values(0).unique()  # we don't reuse existing featureIds from above just to be sure
+    grouped_dfs = (
+        [df.xs(feature_id, axis=1, level=0, drop_level=False) for feature_id in feature_ids]
+        if df.columns.nlevels > 1
+        else [df]
+    )
 
     aggregated_dfs = []
     for grouped_df in grouped_dfs:

--- a/poetry.lock
+++ b/poetry.lock
@@ -1472,13 +1472,13 @@ dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
 name = "python-dateutil"
-version = "2.8.2"
+version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 files = [
-    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
-    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+    {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
+    {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
 ]
 
 [package.dependencies]

--- a/tests/processing/test_depth_aggregation.py
+++ b/tests/processing/test_depth_aggregation.py
@@ -44,8 +44,8 @@ def test_depth_aggregation(start: int, end: int, aggregation_window: int, top_le
 
     # Act
     aggregated_df = depth_aggregation(df, aggregation_window=aggregation_window)
-    grouped = df.groupby(level=0, axis=1)
-    grouped_dfs = [grouped.get_group(group_name) for group_name in grouped.groups]
+    feature_ids = df.columns.get_level_values(0).unique()  # we don't reuse existing featureIds from above just to be sure
+    grouped_dfs = [df.xs(feature_id, axis=1, level=0, drop_level=False) for feature_id in feature_ids]
     expected = reduce(
         lambda acc, obj: acc + obj,
         map(

--- a/tests/processing/test_depth_aggregation.py
+++ b/tests/processing/test_depth_aggregation.py
@@ -10,14 +10,14 @@ from fiberoptics.common.processing import depth_aggregation
 
 
 @pytest.mark.parametrize(
-    "start,end,aggregation_window,top_level_length",
+    "start,end,aggregation_window,num_features",
     [
         (0, 1000, 10, 1),
         (10, 100, 5, 2),
         (500, 5000, 2, 5),
     ],
 )
-def test_depth_aggregation(start: int, end: int, aggregation_window: int, top_level_length: int):
+def test_depth_aggregation(start: int, end: int, aggregation_window: int, num_features: int):
     # Arrange
     # Generate example data
     num_intervals = 10
@@ -25,7 +25,7 @@ def test_depth_aggregation(start: int, end: int, aggregation_window: int, top_le
     loci_range = range(start, end + 1)  # From start to end, inclusive
 
     # Create the multiindex column
-    feature_ids = [f"feature{i}" for i in range(0, top_level_length)]
+    feature_ids = [f"feature{i}" for i in range(0, num_features)]
     loci = loci_range
 
     columns = pd.MultiIndex.from_product([feature_ids, loci], names=["featureId", "loci"])


### PR DESCRIPTION
It pollutes GAD logs in Radix soooo much that it is barely possible to navigate there.