### PR TITLE
Fix caching for synch credential

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,6 +178,9 @@ cython_debug/
 ### PyCharm config files ###
 .idea
 
+### MacOS ###
+.DS_Store
+
 # Support for Project snippet scope
 
 # End of https://www.toptal.com/developers/gitignore/api/python,visualstudiocode

--- a/fiberoptics/common/auth/_async.py
+++ b/fiberoptics/common/auth/_async.py
@@ -52,9 +52,9 @@ class AsyncCredential(BaseCredential, AsyncTokenCredential):
                 logger.debug(f"Failed to instantiate browser credential: {exc}")
 
         for credential_type in (
-            AsyncAzureCliCredential,
             AsyncWorkloadIdentityCredential,
             AsyncManagedIdentityCredential,
+            AsyncAzureCliCredential,
         ):
             try:
                 credentials.append(credential_type())

--- a/fiberoptics/common/auth/_async.py
+++ b/fiberoptics/common/auth/_async.py
@@ -26,12 +26,12 @@ class AsyncCredential(BaseCredential, AsyncTokenCredential):
 
     async def get_token(self, *scopes: Any, **kwargs: Any) -> AccessToken:
         scopes_tuple = self.build_scopes_tuple(scopes)
-        cached = self.get_cached_token(scopes_tuple)
+        cached = self.get_cached_token(scopes_tuple, kwargs)
         if cached:
             return cached
 
         token = await self.credential.get_token(*scopes_tuple, **kwargs)
-        self.store_cached_token(scopes_tuple, token)
+        self.store_cached_token(scopes_tuple, kwargs, token)
         return token
 
     def build_credential(self) -> AsyncChainedTokenCredential:

--- a/fiberoptics/common/auth/_base.py
+++ b/fiberoptics/common/auth/_base.py
@@ -18,7 +18,7 @@ class BaseCredential(ABC):
         self.resource_id = resource_id
         self.scope = f"{resource_id}/.default" if resource_id else None
         self._kwargs = kwargs
-        self._cached_access_tokens: dict[tuple[str, ...], AccessToken] = {}
+        self._cached_access_tokens: dict[tuple, AccessToken] = {}
         self._credential = self.build_credential()
 
     @property
@@ -28,14 +28,26 @@ class BaseCredential(ABC):
     def build_scopes_tuple(self, scopes: tuple[Any, ...]) -> tuple[str, ...]:
         return tuple([self.scope] if len(scopes) == 0 and self.scope else scopes)
 
-    def get_cached_token(self, scopes_tuple: tuple[str, ...]) -> AccessToken | None:
-        token = self._cached_access_tokens.get(scopes_tuple)
+    @staticmethod
+    def _cache_key(scopes_tuple: tuple[str, ...], kwargs: dict[str, Any]) -> tuple:
+        tenant_id = kwargs.get("tenant_id")
+        enable_cae = kwargs.get("enable_cae", False)
+        return (scopes_tuple, tenant_id, enable_cae)
+
+    def get_cached_token(self, scopes_tuple: tuple[str, ...], kwargs: dict[str, Any]) -> AccessToken | None:
+        if kwargs.get("claims"):
+            return None
+        key = self._cache_key(scopes_tuple, kwargs)
+        token = self._cached_access_tokens.get(key)
         if token is not None and int(time.time()) < token.expires_on - self._cache_skew:
             return token
         return None
 
-    def store_cached_token(self, scopes_tuple: tuple[str, ...], token: AccessToken) -> None:
-        self._cached_access_tokens[scopes_tuple] = token
+    def store_cached_token(self, scopes_tuple: tuple[str, ...], kwargs: dict[str, Any], token: AccessToken) -> None:
+        if kwargs.get("claims"):
+            return
+        key = self._cache_key(scopes_tuple, kwargs)
+        self._cached_access_tokens[key] = token
 
     def get_browser_kwargs(self) -> dict[str, Any]:
         return {

--- a/fiberoptics/common/auth/_base.py
+++ b/fiberoptics/common/auth/_base.py
@@ -7,11 +7,8 @@ from abc import ABC, abstractmethod
 from typing import Any, ClassVar
 
 from azure.core.credentials import AccessToken
-from azure.identity import AzureCliCredential, ChainedTokenCredential
-from azure.identity.aio import (
-    AzureCliCredential as AsyncAzureCliCredential,
-    ChainedTokenCredential as AsyncChainedTokenCredential,
-)
+from azure.identity import ChainedTokenCredential
+from azure.identity.aio import ChainedTokenCredential as AsyncChainedTokenCredential
 
 
 class BaseCredential(ABC):
@@ -21,7 +18,7 @@ class BaseCredential(ABC):
         self.resource_id = resource_id
         self.scope = f"{resource_id}/.default" if resource_id else None
         self._kwargs = kwargs
-        self._azure_cli_access_tokens: dict[tuple[str, ...], AccessToken] = {}
+        self._cached_access_tokens: dict[tuple[str, ...], AccessToken] = {}
         self._credential = self.build_credential()
 
     @property
@@ -32,17 +29,13 @@ class BaseCredential(ABC):
         return tuple([self.scope] if len(scopes) == 0 and self.scope else scopes)
 
     def get_cached_token(self, scopes_tuple: tuple[str, ...]) -> AccessToken | None:
-        successful = getattr(self.credential, "_successful_credential", None)
-        if successful and isinstance(successful, (AzureCliCredential, AsyncAzureCliCredential)):
-            token = self._azure_cli_access_tokens.get(scopes_tuple)
-            if token is not None and int(time.time()) < token.expires_on - self._cache_skew:
-                return token
+        token = self._cached_access_tokens.get(scopes_tuple)
+        if token is not None and int(time.time()) < token.expires_on - self._cache_skew:
+            return token
         return None
 
     def store_cached_token(self, scopes_tuple: tuple[str, ...], token: AccessToken) -> None:
-        successful = getattr(self.credential, "_successful_credential", None)
-        if successful and isinstance(successful, (AzureCliCredential, AsyncAzureCliCredential)):
-            self._azure_cli_access_tokens[scopes_tuple] = token
+        self._cached_access_tokens[scopes_tuple] = token
 
     def get_browser_kwargs(self) -> dict[str, Any]:
         return {

--- a/fiberoptics/common/auth/_sync.py
+++ b/fiberoptics/common/auth/_sync.py
@@ -51,9 +51,9 @@ class Credential(BaseCredential, TokenCredential):
                 logger.debug(f"Failed to instantiate browser credential: {exc}")
 
         for credential_type in (
-            AzureCliCredential,
             WorkloadIdentityCredential,
             ManagedIdentityCredential,
+            AzureCliCredential,
         ):
             try:
                 credentials.append(credential_type())

--- a/fiberoptics/common/auth/_sync.py
+++ b/fiberoptics/common/auth/_sync.py
@@ -25,12 +25,12 @@ class Credential(BaseCredential, TokenCredential):
 
     def get_token(self, *scopes: Any, **kwargs: Any) -> AccessToken:
         scopes_tuple = self.build_scopes_tuple(scopes)
-        cached = self.get_cached_token(scopes_tuple)
+        cached = self.get_cached_token(scopes_tuple, kwargs)
         if cached:
             return cached
 
         token = self.credential.get_token(*scopes_tuple, **kwargs)
-        self.store_cached_token(scopes_tuple, token)
+        self.store_cached_token(scopes_tuple, kwargs, token)
         return token
 
     def build_credential(self) -> ChainedTokenCredential:

--- a/fiberoptics/common/auth/_sync.py
+++ b/fiberoptics/common/auth/_sync.py
@@ -6,7 +6,12 @@ import logging
 from typing import Any
 
 from azure.core.credentials import AccessToken, TokenCredential
-from azure.identity import ChainedTokenCredential, DefaultAzureCredential
+from azure.identity import (
+    AzureCliCredential,
+    ChainedTokenCredential,
+    ManagedIdentityCredential,
+    WorkloadIdentityCredential,
+)
 
 from ._base import BaseCredential
 from ._browser import SyncInteractiveBrowserCredential, use_browser_credentials
@@ -45,17 +50,15 @@ class Credential(BaseCredential, TokenCredential):
             except BaseException as exc:
                 logger.debug(f"Failed to instantiate browser credential: {exc}")
 
-        try:
-            options = {
-                "exclude_developer_cli_credential": True,
-                "exclude_environment_credential": True,
-                "exclude_powershell_credential": True,
-                "exclude_visual_studio_code_credential": True,
-                "exclude_interactive_browser_credential": True,
-            }
-            credentials.append(DefaultAzureCredential(**options))
-        except BaseException as exc:
-            logger.debug(f"Failed to instantiate DefaultAzureCredential: {exc}")
+        for credential_type in (
+            AzureCliCredential,
+            WorkloadIdentityCredential,
+            ManagedIdentityCredential,
+        ):
+            try:
+                credentials.append(credential_type())
+            except BaseException as exc:
+                logger.debug(f"Failed to instantiate {credential_type.__name__}: {exc}")
 
         if not credentials:
             raise RuntimeError("No Azure credentials could be instantiated")


### PR DESCRIPTION
Closes https://github.com/equinor/fiberoptics-common/issues/58
Related to: https://github.com/equinor/fiberoptics-fotonepy/pull/279

The thing is - we are already supposed to have caching in fotonepy clients hidden from fotonepy itself. 

But there are a few moments with it. As you can see here, the credential parameter is optional in the fotone client constructor https://github.com/equinor/fiberoptics-fotonepy/blob/d4be2201f9f373d0f0c30df3e596721bbd9c063c/fiberoptics/fotonepy/fotone.py#L48 and if it is not provided the code will try to instantiate the default credential based on credential mixin https://github.com/equinor/fiberoptics-fotonepy/blob/master/fiberoptics/fotonepy/credential_mixin.py , and that one takes credential class from fiberoptics-common as you can see https://github.com/equinor/fiberoptics-fotonepy/blob/d4be2201f9f373d0f0c30df3e596721bbd9c063c/fiberoptics/fotonepy/credential_mixin.py#L5 -> https://github.com/equinor/fiberoptics-common/blob/1d0e118bda07bc475d65296577d8214e30076476/fiberoptics/common/auth/_async.py#L23 or https://github.com/equinor/fiberoptics-common/blob/1d0e118bda07bc475d65296577d8214e30076476/fiberoptics/common/auth/_sync.py#L17.
This is the desired behaviour. I added that option to provide your own instance of credential to FotoneClient just in case, for weird cases when you need some very custom credential objects.

So then when it uses Credential classes from fiberoptics-common it caches tokens, you can see it in its base class here https://github.com/equinor/fiberoptics-common/blob/1d0e118bda07bc475d65296577d8214e30076476/fiberoptics/common/auth/_base.py#L34
So you don't see this caching in your benchmark because of this
client = FotoneClient(credential=AzureCliCredential())
Try to do this:
client = FotoneClient()
It will force it to use our custom credential from fiberoptics-common.

Spoiler: it won't work either. What I found is a bug in my code, this line https://github.com/equinor/fiberoptics-common/blob/1d0e118bda07bc475d65296577d8214e30076476/fiberoptics/common/auth/_base.py#L36 it checks credential type againt (AzureCliCredential, AsyncAzureCliCredential), and that works for the async clients, because of this https://github.com/equinor/fiberoptics-common/blob/1d0e118bda07bc475d65296577d8214e30076476/fiberoptics/common/auth/_async.py#L54-L60 , but its counterpart in the sync client follows a different logic https://github.com/equinor/fiberoptics-common/blob/1d0e118bda07bc475d65296577d8214e30076476/fiberoptics/common/auth/_sync.py#L48-L56 , so it wraps its type into DefaultAzureCredential (because Microsoft has two very different toolsets for sync and async credential), and therefore that type check fails and caching does not work for the sync client. It should work fine for the async client.