### PR TITLE
Forward AZURE_CLIENT_ID to ManagedIdentityCredential

### DIFF
--- a/fiberoptics/common/__init__.py
+++ b/fiberoptics/common/__init__.py
@@ -1,3 +1,3 @@
 from .misc import *  # noqa
 
-__version__ = "2.3.4"
+__version__ = "2.3.5"

--- a/fiberoptics/common/auth/_async.py
+++ b/fiberoptics/common/auth/_async.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from typing import Any
 
 from azure.core.credentials import AccessToken
@@ -51,13 +52,13 @@ class AsyncCredential(BaseCredential, AsyncTokenCredential):
             except BaseException as exc:
                 logger.debug(f"Failed to instantiate browser credential: {exc}")
 
-        for credential_type in (
-            AsyncWorkloadIdentityCredential,
-            AsyncManagedIdentityCredential,
-            AsyncAzureCliCredential,
+        for credential_type, type_kwargs in (
+            (AsyncWorkloadIdentityCredential, {}),
+            (AsyncManagedIdentityCredential, {"client_id": os.environ.get("AZURE_CLIENT_ID")}),
+            (AsyncAzureCliCredential, {}),
         ):
             try:
-                credentials.append(credential_type())
+                credentials.append(credential_type(**type_kwargs))
             except BaseException as exc:
                 logger.debug(f"Failed to instantiate {credential_type.__name__}: {exc}")
 

--- a/fiberoptics/common/auth/_async.py
+++ b/fiberoptics/common/auth/_async.py
@@ -54,7 +54,7 @@ class AsyncCredential(BaseCredential, AsyncTokenCredential):
 
         for credential_type, type_kwargs in (
             (AsyncWorkloadIdentityCredential, {}),
-            (AsyncManagedIdentityCredential, {"client_id": os.environ.get("AZURE_CLIENT_ID")}),
+            (AsyncManagedIdentityCredential, {"client_id": os.environ.get("AZURE_CLIENT_ID") or None}),
             (AsyncAzureCliCredential, {}),
         ):
             try:

--- a/fiberoptics/common/auth/_sync.py
+++ b/fiberoptics/common/auth/_sync.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from typing import Any
 
 from azure.core.credentials import AccessToken, TokenCredential
@@ -50,13 +51,13 @@ class Credential(BaseCredential, TokenCredential):
             except BaseException as exc:
                 logger.debug(f"Failed to instantiate browser credential: {exc}")
 
-        for credential_type in (
-            WorkloadIdentityCredential,
-            ManagedIdentityCredential,
-            AzureCliCredential,
+        for credential_type, type_kwargs in (
+            (WorkloadIdentityCredential, {}),
+            (ManagedIdentityCredential, {"client_id": os.environ.get("AZURE_CLIENT_ID")}),
+            (AzureCliCredential, {}),
         ):
             try:
-                credentials.append(credential_type())
+                credentials.append(credential_type(**type_kwargs))
             except BaseException as exc:
                 logger.debug(f"Failed to instantiate {credential_type.__name__}: {exc}")
 

--- a/fiberoptics/common/auth/_sync.py
+++ b/fiberoptics/common/auth/_sync.py
@@ -53,7 +53,7 @@ class Credential(BaseCredential, TokenCredential):
 
         for credential_type, type_kwargs in (
             (WorkloadIdentityCredential, {}),
-            (ManagedIdentityCredential, {"client_id": os.environ.get("AZURE_CLIENT_ID")}),
+            (ManagedIdentityCredential, {"client_id": os.environ.get("AZURE_CLIENT_ID") or None}),
             (AzureCliCredential, {}),
         ):
             try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ omit = ["*/tests/*"]
 
 [tool.poetry]
 name = "fiberoptics-common"
-version = "2.3.4"
+version = "2.3.5"
 description = ""
 authors = []
 repository = "https://github.com/equinor/fiberoptics-common"
@@ -69,7 +69,7 @@ sphinx_design = "^0.5.0"
 sphinx_rtd_theme = "^2.0.0"
 
 [tool.bumpversion]
-current_version = "2.3.4"
+current_version = "2.3.5"
 commit = true
 message = "Bump version: {current_version} → {new_version}"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(\\-(?P<release>[a-z]+))?"


### PR DESCRIPTION
After #57 replaced `DefaultAzureCredential` with an explicit list of credentials, authentication started failing on AzureML compute clusters with `SystemAssignedIdentityNotFound`, even though `AZURE_CLIENT_ID` was set in the environment.

The reason is that `DefaultAzureCredential` automaticaly picks up `AZURE_CLIENT_ID` and uses it to authenticate as a user-assigned managed identity. The explicit authentication chain does not, so on clusters that only have a user-assigned identity (and no system-assigned one), there's no identity left for the chain to try.

This PR passes `AZURE_CLIENT_ID` to `ManagedIdentityCredential` in both the sync and async authentication chains. Since `client_id` defaults to `None` ( https://learn.microsoft.com/en-us/python/api/azure-identity/azure.identity.managedidentitycredential?view=azure-python ), the behaviour is unchanged when`AZURE_CLIENT_ID` is not set.